### PR TITLE
Deathclip rate prompt

### DIFF
--- a/UI/AuctionHouse/DeathClipRatePrompt.lua
+++ b/UI/AuctionHouse/DeathClipRatePrompt.lua
@@ -64,7 +64,7 @@ local function CreateReviewPrompt()
     reviewGroup:SetPadding(10, 15)
     frame:AddChild(reviewGroup)
 
-    -- Static label
+    -- Static label for "Write your review for"
     local staticLabel = AceGUI:Create("Label")
     staticLabel:SetFontObject(GameFontNormal)
     local label = L["Write your review for"]
@@ -72,25 +72,11 @@ local function CreateReviewPrompt()
     staticLabel:SetHeight(16)
     reviewGroup:AddChild(staticLabel)
 
-    -- Static “Played time” label
-    local staticPlayed = staticLabel.frame:GetParent():CreateFontString(nil, "OVERLAY", "GameFontNormal")
-    staticPlayed:SetPoint("LEFT", staticLabel.frame, "RIGHT", 80, 0)
-    staticPlayed:SetText("Played time")
-    staticPlayed:Hide()
-
-    -- Dynamic time label, anchored to the static one
-    local playedTimeLabel = staticPlayed:GetParent():CreateFontString(nil, "OVERLAY", "GameFontNormal")
-    -- anchor LEFT edge of this to RIGHT edge of staticPlayed, with a little padding
-    playedTimeLabel:SetPoint("TOPLEFT", staticPlayed, "BOTTOMLEFT", 0, -8)
-    playedTimeLabel:SetText("")
-    playedTimeLabel:SetTextColor(1, 1, 1, 1)
-
-
-    -- Add padding between label and name
-    local labelPadding = AceGUI:Create("MinimalFrame")
-    labelPadding:SetFullWidth(true)
-    labelPadding:SetHeight(2)
-    reviewGroup:AddChild(labelPadding)
+    -- Static Played Time label (this will appear below the Target Name)
+    local rateClip = staticLabel.frame:GetParent():CreateFontString(nil, "OVERLAY", "GameFontNormal")
+    rateClip:SetPoint("TOPLEFT", staticLabel.frame, "TOPRIGHT", 60, 0)
+    rateClip:SetText("Rate Clip")
+    rateClip:SetHeight(16)
 
     -- Target name label
     local targetLabel = AceGUI:Create("Label")
@@ -98,6 +84,27 @@ local function CreateReviewPrompt()
     targetLabel:SetHeight(20)
     targetLabel:SetFullWidth(true)
     reviewGroup:AddChild(targetLabel)
+
+
+    -- Static Played Time label (this will appear below the Target Name)
+    local staticPlayed = staticLabel.frame:GetParent():CreateFontString(nil, "OVERLAY", "GameFontNormal")
+    staticPlayed:SetPoint("LEFT", targetLabel.frame, "LEFT", 0, -20)
+    staticPlayed:SetText("Played time")
+    staticPlayed:SetHeight(16)
+
+    -- Played time label (created dynamically with CreateFontString and aligned to the right)
+    local playedTimeLabel = staticLabel.frame:GetParent():CreateFontString(nil, "OVERLAY", "GameFontNormal")
+    playedTimeLabel:SetPoint("TOPLEFT", staticPlayed, "TOPRIGHT", 180, 0)
+    playedTimeLabel:SetHeight(20)
+    playedTimeLabel:SetText("") -- Set this dynamically later
+
+
+
+    -- Add padding between label and name
+    local labelPadding = AceGUI:Create("MinimalFrame")
+    labelPadding:SetFullWidth(true)
+    labelPadding:SetHeight(2)
+    reviewGroup:AddChild(labelPadding)
 
 
     local submitButton = AceGUI:Create("Button")

--- a/UI/AuctionHouse/DeathClipRatePrompt.lua
+++ b/UI/AuctionHouse/DeathClipRatePrompt.lua
@@ -25,7 +25,7 @@ local function CreateBorderedGroup(relativeWidth, height)
     local border = CreateFrame("Frame", nil, group.frame)
     border:SetAllPoints(group.frame)
     border:SetBackdrop(PaneBackdrop)
-    border:SetBackdropColor(0.15, 0.15, 0.13, 1) -- #272522
+    border:SetBackdropColor(15/255, 15/255, 15/255, 1)
     border:SetBackdropBorderColor(0.4, 0.4, 0.4)
 
     return group
@@ -38,7 +38,7 @@ local function CreateReviewPrompt()
     frame.titlebg_l:Hide()
     frame.titlebg_r:Hide()
     frame:SetLayout("Flow")
-    frame:SetWidth(410)
+    frame:SetWidth(350)
     frame:SetHeight(350)
 
     ns.CustomFrameSetAllPoints()
@@ -46,7 +46,7 @@ local function CreateReviewPrompt()
 
 
     -- Here, we're passing `true` to use custom padding
-    frame:OnWidthSet(410, true) -- Apply custom width adjustment
+    frame:OnWidthSet(350, true) -- Apply custom width adjustment
     frame:OnHeightSet(350, true) -- Apply custom height adjustment
 
     -- Close button
@@ -72,42 +72,52 @@ local function CreateReviewPrompt()
     -- Review Group
     ----------------------------------------------------------------------------
     local submitButton
-    local reviewGroup = CreateBorderedGroup(1, 340)
-    reviewGroup:SetPadding(10, 20)
+    local reviewGroup = CreateBorderedGroup(1, 350)
+    reviewGroup:SetPadding(25, 20)
     frame:AddChild(reviewGroup)
 
-    -- Static label for "Write your review for"
-    local staticLabel = AceGUI:Create("Label")
-    staticLabel:SetFontObject(GameFontNormalLarge) -- Using a larger font object
-    local label = L["Write your review for"]
-    staticLabel:SetText("|cFFFFD100".. label .. "|r")
-    staticLabel:SetHeight(22)  -- Adjusted for larger font size
-    reviewGroup:AddChild(staticLabel)
+    ---- Static label for "Write your review for"
+    --local staticLabel = AceGUI:Create("Label")
+    --staticLabel:SetFontObject(GameFontNormalLarge) -- Using a larger font object
+    --local label = L["Write your review for"]
+    --staticLabel:SetText("|cFFFFD100".. label .. "|r")
+    --staticLabel:SetHeight(22)  -- Adjusted for larger font size
+    --reviewGroup:AddChild(staticLabel)
+    --
+    ---- Static Played Time label (this will appear below the Target Name)
+    --local rateClip = staticLabel.frame:GetParent():CreateFontString(nil, "OVERLAY", "GameFontNormalLarge") -- Using a larger font object
+    --rateClip:SetPoint("TOPLEFT", staticLabel.frame, "TOPRIGHT", 15, 3)
+    --rateClip:SetText("Rate Clip")
+    --rateClip:SetHeight(22)  -- Adjusted for larger font size
 
-    -- Static Played Time label (this will appear below the Target Name)
-    local rateClip = staticLabel.frame:GetParent():CreateFontString(nil, "OVERLAY", "GameFontNormalLarge") -- Using a larger font object
-    rateClip:SetPoint("TOPLEFT", staticLabel.frame, "TOPRIGHT", 60, 0)
-    rateClip:SetText("Rate Clip")
-    rateClip:SetHeight(22)  -- Adjusted for larger font size
+    -- Add padding between name and star
+    local labelPadding = AceGUI:Create("MinimalFrame")
+    labelPadding:SetFullWidth(true)
+    labelPadding:SetHeight(10)
+    reviewGroup:AddChild(labelPadding)
 
-    -- Target name label
+    -- Creating the target label
     local targetLabel = AceGUI:Create("Label")
     targetLabel:SetFontObject(GameFontNormalLarge)  -- Using a larger font object
-    targetLabel:SetHeight(24)  -- Adjusted for larger font size
     targetLabel:SetFullWidth(true)
     reviewGroup:AddChild(targetLabel)
 
+    -- Accessing the FontString and setting the text color
+    local labelFontString = targetLabel.label  -- Accessing the label field directly
+    labelFontString:SetScale(1.5)
+    labelFontString:ClearAllPoints()
+    labelFontString:SetPoint("LEFT", targetLabel.frame, "LEFT", 3, 0)
+
     -- Static Played Time label (this will appear below the Target Name)
-    local staticPlayed = staticLabel.frame:GetParent():CreateFontString(nil, "OVERLAY", "GameFontNormalLarge")  -- Using a larger font object
-    staticPlayed:SetPoint("LEFT", targetLabel.frame, "LEFT", 0, -30)
-    staticPlayed:SetText("Played time")
-    staticPlayed:SetHeight(22)  -- Adjusted for larger font size
+    local playedLabel = targetLabel.frame:GetParent():CreateFontString(nil, "OVERLAY", "GameFontDisableLarge")  -- Using a larger font object
+    playedLabel:SetPoint("LEFT", targetLabel.frame, "LEFT", 4, -30)
+    playedLabel:SetText("Время в игре:")
 
     -- Played time label (created dynamically with CreateFontString and aligned to the right)
-    local playedTimeLabel = staticLabel.frame:GetParent():CreateFontString(nil, "OVERLAY", "GameFontNormalLarge")  -- Using a larger font object
-    playedTimeLabel:SetPoint("TOPLEFT", staticPlayed, "TOPRIGHT", 180, 0)
-    playedTimeLabel:SetHeight(24)  -- Adjusted for larger font size
-    playedTimeLabel:SetText("") -- Set this dynamically later
+    local playedTime = targetLabel.frame:GetParent():CreateFontString(nil, "OVERLAY", "GameFontNormalLarge")  -- Using a larger font object
+    playedTime:SetPoint("RIGHT", playedLabel, "RIGHT", 176, 0)
+    playedTime:SetText("") -- Set this dynamically later
+    playedTime:SetTextColor(1, 1, 1, 1) -- White color with full opacity
 
     -- Add padding between name and star
     local labelPadding = AceGUI:Create("MinimalFrame")
@@ -127,7 +137,7 @@ local function CreateReviewPrompt()
         hitboxPadX = 6,
         textWidth = 26,
         labelFont = "GameFontNormalLarge",
-        leftPadding = 10,  -- Set the left padding to 20px
+        leftPadding = 5,  -- Set the left padding to 20px
     })
 
 
@@ -144,7 +154,8 @@ local function CreateReviewPrompt()
     -- Comment box
     local reviewEdit = AceGUI:Create("MultiLineEditBoxCustom")
     reviewEdit:SetLabel("")
-    reviewEdit:SetFullWidth(true)
+    reviewEdit:SetWidth(400)
+
     reviewEdit:DisableButton(true)
     reviewEdit:SetMaxLetters(90+45)
     reviewEdit:SetNumLines(6)
@@ -179,11 +190,11 @@ local function CreateReviewPrompt()
     -- 1) Add some inner padding so the text sits inset
     reviewEdit.editBox:SetTextInsets(6, 6, 6, 6)
 
-    -- Add padding between info and review group
-    local bottomPadding = AceGUI:Create("MinimalFrame")
-    bottomPadding:SetFullWidth(true)
-    bottomPadding:SetHeight(5)
-    frame:AddChild(bottomPadding)
+    ---- Add padding between info and review group
+    --local bottomPadding = AceGUI:Create("MinimalFrame")
+    --bottomPadding:SetFullWidth(true)
+    --bottomPadding:SetHeight(5)
+    --frame:AddChild(bottomPadding)
 
 
     -- Collect references for later access
@@ -191,7 +202,8 @@ local function CreateReviewPrompt()
         frame = frame,
         closeButton = closeButton,
         targetLabel = targetLabel,
-        playedTimeLabel = playedTimeLabel,
+        labelFontString = labelFontString,
+        playedTime = playedTime,
         starRating = starRating,
         reviewEdit = reviewEdit,
         submitButton = submitButton
@@ -203,7 +215,18 @@ local function CreateReviewPrompt()
     function prompt:Show()
         PlaySound(SOUNDKIT.IG_MAINMENU_OPEN)
         self.frame:Show()
+
+        -- Ensure changes after frame is rendered, 0.001 :)
+        C_Timer:After(0.001, function()
+            if self.labelFontString then
+                self.labelFontString:SetScale(1.5)  -- Set the scale
+                self.labelFontString:ClearAllPoints()  -- Clear any previous points
+                -- Position it 3px to the right in X-axis
+                self.labelFontString:SetPoint("LEFT", self.targetLabel.frame, "LEFT", 3, 0)
+            end
+        end)
     end
+
 
     function prompt:Hide()
         PlaySound(SOUNDKIT.IG_MAINMENU_CLOSE)
@@ -213,17 +236,26 @@ local function CreateReviewPrompt()
     ----------------------------------------------------------------------------
     -- Setters
     ----------------------------------------------------------------------------
-    function prompt:SetTargetName(name)
+    -- Define the SetTargetName function with an additional parameter for classColor
+    function prompt:SetTargetName(name, classColor)
+        -- Set the target name
         self.targetLabel:SetText(name)
+
+        -- Set the text color based on classColor (if available)
+        if classColor then
+            labelFontString:SetTextColor(classColor.r, classColor.g, classColor.b)
+        else
+            labelFontString:SetTextColor(1, 1, 1) -- Fallback to white
+        end
     end
 
     function prompt:SetPlayedTime(seconds)
         if seconds then
-            staticPlayed:Show()
-            self.playedTimeLabel:SetText(SecondsToTime(seconds))
+            playedLabel:Show()
+            self.playedTime:SetText(SecondsToTime(seconds))
         else
-            staticPlayed:Hide()
-            self.playedTimeLabel:SetText("")
+            playedLabel:Hide()
+            self.playedTime:SetText("")
         end
     end
 
@@ -301,7 +333,16 @@ function ns.ShowDeathClipRatePrompt(clip, overrideUser)
     prompt.submitButton:SetText(submitText)
 
     -- Update the display
-    prompt:SetTargetName(ns.GetDisplayName(clip.characterName))
+    -- Set class color from RAID_CLASS_COLORS within the current scope
+    local classColor = RAID_CLASS_COLORS[clip.class]
+    if classColor then
+        -- Now pass both the name and classColor when calling SetTargetName
+        prompt:SetTargetName(ns.GetDisplayName(clip.characterName), classColor)
+    else
+        -- If no class color, pass nil as the second argument
+        prompt:SetTargetName(ns.GetDisplayName(clip.characterName), nil)
+    end
+
     prompt:SetPlayedTime(clip.playedTime)
 
 

--- a/UI/AuctionHouse/DeathClipRatePrompt.lua
+++ b/UI/AuctionHouse/DeathClipRatePrompt.lua
@@ -51,72 +51,57 @@ local function CreateReviewPrompt()
         PlaySound(SOUNDKIT.IG_MAINMENU_CLOSE)
     end)
 
-    -- Add top padding
-    local topPadding = AceGUI:Create("SimpleGroup")
-    topPadding:SetFullWidth(true)
-    topPadding:SetHeight(4)
-    frame:AddChild(topPadding)
+    ---- Add top padding
+    --local topPadding = AceGUI:Create("SimpleGroup")
+    --topPadding:SetFullWidth(true)
+    --topPadding:SetHeight(4)
+    --frame:AddChild(topPadding)
 
     ----------------------------------------------------------------------------
     -- Review Group
     ----------------------------------------------------------------------------
-    local reviewGroup = CreateBorderedGroup(1, 240)
-    reviewGroup:SetPadding(10, 15)
+    local submitButton
+    local reviewGroup = CreateBorderedGroup(1, 300)
+    reviewGroup:SetPadding(10, 20)
     frame:AddChild(reviewGroup)
 
     -- Static label for "Write your review for"
     local staticLabel = AceGUI:Create("Label")
-    staticLabel:SetFontObject(GameFontNormal)
+    staticLabel:SetFontObject(GameFontNormalLarge) -- Using a larger font object
     local label = L["Write your review for"]
     staticLabel:SetText("|cFFFFD100".. label .. "|r")
-    staticLabel:SetHeight(16)
+    staticLabel:SetHeight(22)  -- Adjusted for larger font size
     reviewGroup:AddChild(staticLabel)
 
     -- Static Played Time label (this will appear below the Target Name)
-    local rateClip = staticLabel.frame:GetParent():CreateFontString(nil, "OVERLAY", "GameFontNormal")
+    local rateClip = staticLabel.frame:GetParent():CreateFontString(nil, "OVERLAY", "GameFontNormalLarge") -- Using a larger font object
     rateClip:SetPoint("TOPLEFT", staticLabel.frame, "TOPRIGHT", 60, 0)
     rateClip:SetText("Rate Clip")
-    rateClip:SetHeight(16)
+    rateClip:SetHeight(22)  -- Adjusted for larger font size
 
     -- Target name label
     local targetLabel = AceGUI:Create("Label")
-    targetLabel:SetFontObject(GameFontNormal)
-    targetLabel:SetHeight(20)
+    targetLabel:SetFontObject(GameFontNormalLarge)  -- Using a larger font object
+    targetLabel:SetHeight(24)  -- Adjusted for larger font size
     targetLabel:SetFullWidth(true)
     reviewGroup:AddChild(targetLabel)
 
-
     -- Static Played Time label (this will appear below the Target Name)
-    local staticPlayed = staticLabel.frame:GetParent():CreateFontString(nil, "OVERLAY", "GameFontNormal")
-    staticPlayed:SetPoint("LEFT", targetLabel.frame, "LEFT", 0, -20)
+    local staticPlayed = staticLabel.frame:GetParent():CreateFontString(nil, "OVERLAY", "GameFontNormalLarge")  -- Using a larger font object
+    staticPlayed:SetPoint("LEFT", targetLabel.frame, "LEFT", 0, -30)
     staticPlayed:SetText("Played time")
-    staticPlayed:SetHeight(16)
+    staticPlayed:SetHeight(22)  -- Adjusted for larger font size
 
     -- Played time label (created dynamically with CreateFontString and aligned to the right)
-    local playedTimeLabel = staticLabel.frame:GetParent():CreateFontString(nil, "OVERLAY", "GameFontNormal")
+    local playedTimeLabel = staticLabel.frame:GetParent():CreateFontString(nil, "OVERLAY", "GameFontNormalLarge")  -- Using a larger font object
     playedTimeLabel:SetPoint("TOPLEFT", staticPlayed, "TOPRIGHT", 180, 0)
-    playedTimeLabel:SetHeight(20)
+    playedTimeLabel:SetHeight(24)  -- Adjusted for larger font size
     playedTimeLabel:SetText("") -- Set this dynamically later
-
-
-
-    -- Add padding between label and name
-    local labelPadding = AceGUI:Create("MinimalFrame")
-    labelPadding:SetFullWidth(true)
-    labelPadding:SetHeight(2)
-    reviewGroup:AddChild(labelPadding)
-
-
-    local submitButton = AceGUI:Create("Button")
-    submitButton:SetText(L["Submit Review"])
-    submitButton:SetFullWidth(true)
-    submitButton:SetHeight(40)
-    submitButton:SetDisabled(true)
 
     -- Add padding between name and star
     local labelPadding = AceGUI:Create("MinimalFrame")
     labelPadding:SetFullWidth(true)
-    labelPadding:SetHeight(10)
+    labelPadding:SetHeight(25)
     reviewGroup:AddChild(labelPadding)
 
     -- Star rating
@@ -131,8 +116,19 @@ local function CreateReviewPrompt()
         hitboxPadX = 6,
         textWidth = 26,
         labelFont = "GameFontNormalLarge",
+        leftPadding = 10,  -- Set the left padding to 20px
     })
+
+
     reviewGroup:AddChild(starRating)
+
+
+
+    ---- Add padding between label and name
+    --local labelPadding = AceGUI:Create("MinimalFrame")
+    --labelPadding:SetFullWidth(true)
+    --labelPadding:SetHeight(2)
+    --reviewGroup:AddChild(labelPadding)
 
     -- Comment box
     local reviewEdit = AceGUI:Create("MultiLineEditBoxCustom")
@@ -144,6 +140,17 @@ local function CreateReviewPrompt()
     reviewEdit:SetHeight(115)
     reviewEdit.editBox:SetFontObject(GameFontNormal)
     reviewEdit.editBox:SetTextColor(1, 1, 1, 0.75)
+    reviewGroup:AddChild(reviewEdit)
+
+
+    submitButton = AceGUI:Create("Button")
+    submitButton:SetText(L["Submit Review"])
+    submitButton:SetFullWidth(true)
+    submitButton:SetHeight(40)
+    submitButton:SetDisabled(true)
+
+    -- Submit Button
+    reviewGroup:AddChild(submitButton)
 
     -- Clear placeholder text on focus
     reviewEdit.editBox:SetScript("OnEditFocusGained", function(self)
@@ -161,16 +168,11 @@ local function CreateReviewPrompt()
     -- 1) Add some inner padding so the text sits inset
     reviewEdit.editBox:SetTextInsets(6, 6, 6, 6)
 
-    reviewGroup:AddChild(reviewEdit)
-
     -- Add padding between info and review group
     local bottomPadding = AceGUI:Create("MinimalFrame")
     bottomPadding:SetFullWidth(true)
     bottomPadding:SetHeight(5)
     frame:AddChild(bottomPadding)
-
-    -- Submit Button
-    frame:AddChild(submitButton)
 
 
     -- Collect references for later access

--- a/UI/AuctionHouse/DeathClipRatePrompt.lua
+++ b/UI/AuctionHouse/DeathClipRatePrompt.lua
@@ -8,7 +8,7 @@ local PaneBackdrop  = {
     bgFile = "Interface\\ChatFrame\\ChatFrameBackground",
     edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
     tile = true, tileSize = 16, edgeSize = 8,
-    insets = { left = 2, right = 2, top = 5, bottom = 2 }
+    insets = { left = 2, right = 2, top = 2, bottom = 2 }
 }
 
 local REVIEW_PLACEHOLDER = L["Write your review ..."]
@@ -23,8 +23,7 @@ local function CreateBorderedGroup(relativeWidth, height)
     end
 
     local border = CreateFrame("Frame", nil, group.frame)
-    border:SetPoint("TOPLEFT", 0, 0)
-    border:SetPoint("BOTTOMRIGHT", 0, 0)
+    border:SetAllPoints(group.frame)
     border:SetBackdrop(PaneBackdrop)
     border:SetBackdropColor(0.15, 0.15, 0.13, 1) -- #272522
     border:SetBackdropBorderColor(0.4, 0.4, 0.4)
@@ -34,10 +33,21 @@ end
 
 local function CreateReviewPrompt()
     local frame = AceGUI:Create("CustomFrame")
-    frame:SetTitle(L["Rate Clip"])
+    frame:SetTitle("")
+    frame.titlebg:Hide()
+    frame.titlebg_l:Hide()
+    frame.titlebg_r:Hide()
     frame:SetLayout("Flow")
     frame:SetWidth(410)
     frame:SetHeight(350)
+
+    ns.CustomFrameSetAllPoints()
+    ns.CustomFrameHideBackDrop()
+
+
+    -- Here, we're passing `true` to use custom padding
+    frame:OnWidthSet(410, true) -- Apply custom width adjustment
+    frame:OnHeightSet(350, true) -- Apply custom height adjustment
 
     -- Close button
     local closeButton = CreateFrame("Button", "GoAHExitButtonDeathRate", frame.frame, "UIPanelCloseButton")
@@ -50,6 +60,7 @@ local function CreateReviewPrompt()
         end
         PlaySound(SOUNDKIT.IG_MAINMENU_CLOSE)
     end)
+    closeButton:Hide()
 
     ---- Add top padding
     --local topPadding = AceGUI:Create("SimpleGroup")
@@ -61,7 +72,7 @@ local function CreateReviewPrompt()
     -- Review Group
     ----------------------------------------------------------------------------
     local submitButton
-    local reviewGroup = CreateBorderedGroup(1, 300)
+    local reviewGroup = CreateBorderedGroup(1, 340)
     reviewGroup:SetPadding(10, 20)
     frame:AddChild(reviewGroup)
 

--- a/UI/CustomFrame.lua
+++ b/UI/CustomFrame.lua
@@ -92,9 +92,9 @@ local methods = {
 		wipe(self.localstatus)
 	end,
 
-	["OnWidthSet"] = function(self, width)
+	["OnWidthSet"] = function(self, width, useCustomPadding)
 		local content = self.content
-		local contentwidth = width - 34
+		local contentwidth = useCustomPadding and (width - 34) or width
 		if contentwidth < 0 then
 			contentwidth = 0
 		end
@@ -102,9 +102,9 @@ local methods = {
 		content.width = contentwidth
 	end,
 
-	["OnHeightSet"] = function(self, height)
+	["OnHeightSet"] = function(self, height, useCustomPadding)
 		local content = self.content
-		local contentheight = height - 57
+		local contentheight = useCustomPadding and (height - 57) or height
 		if contentheight < 0 then
 			contentheight = 0
 		end
@@ -222,14 +222,14 @@ local function Constructor()
 	titletext:SetPoint("TOP", titlebg, "TOP", 0, -14)
 
 	local titlebg_l = frame:CreateTexture(nil, "OVERLAY")
-	titlebg:SetTexture("Interface\\DialogFrame\\UI-DialogBox-Header")
+	titlebg_l:SetTexture("Interface\\DialogFrame\\UI-DialogBox-Header")
 	titlebg_l:SetTexCoord(0.21, 0.31, 0, 0.63)
 	titlebg_l:SetPoint("RIGHT", titlebg, "LEFT")
 	titlebg_l:SetWidth(30)
 	titlebg_l:SetHeight(40)
 
 	local titlebg_r = frame:CreateTexture(nil, "OVERLAY")
-	titlebg:SetTexture("Interface\\DialogFrame\\UI-DialogBox-Header")
+	titlebg_r:SetTexture("Interface\\DialogFrame\\UI-DialogBox-Header")
 	titlebg_r:SetTexCoord(0.67, 0.77, 0, 0.63)
 	titlebg_r:SetPoint("LEFT", titlebg, "RIGHT")
 	titlebg_r:SetWidth(30)
@@ -280,11 +280,20 @@ local function Constructor()
 	content:SetPoint("TOPLEFT", 17, -27)
 	content:SetPoint("BOTTOMRIGHT", -17, 40)
 
+	function ns.CustomFrameSetAllPoints()
+		content:SetAllPoints(frame)
+	end
+	function ns.CustomFrameHideBackDrop()
+		frame:SetBackdrop(nil)
+	end
+
 	local widget = {
 		localstatus = {},
         title = title,
 		titletext   = titletext,
 		titlebg     = titlebg,
+		titlebg_l     = titlebg_l,
+		titlebg_r     = titlebg_r,
 		--sizer_se    = sizer_se,
 		--sizer_s     = sizer_s,
 		--sizer_e     = sizer_e,

--- a/UI/MultiLineEditBoxCustom.lua
+++ b/UI/MultiLineEditBoxCustom.lua
@@ -41,16 +41,18 @@ local function Layout(self)
 	if self.labelHeight == 0 then
 		self.scrollBG:SetPoint("TOP", self.frame, "TOP", 0, 0)
 	else
-		self.scrollBG:SetPoint("TOP", self.label, "BOTTOM", 0, -19)
+		-- Adjusting the top point to 0 instead of -19
+		self.scrollBG:SetPoint("TOP", self.label, "BOTTOM", 0, 0)
 	end
 
 	if self.disablebutton then
-		self.scrollBG:SetPoint("BOTTOMLEFT", self.frame, "BOTTOMLEFT", 3, 3)
+		self.scrollBG:SetPoint("BOTTOMLEFT", self.frame, "BOTTOMLEFT", 0, 0)
 	else
 		-- Place just above the button if not disabled
 		self.scrollBG:SetPoint("BOTTOMLEFT", self.button, "TOPLEFT")
 	end
 
+	-- Ensure the right side of the frame is still aligned correctly
 	self.scrollBG:SetPoint("RIGHT", self.frame, "RIGHT")
 end
 

--- a/UI/Widgets/StarRatingWidget.lua
+++ b/UI/Widgets/StarRatingWidget.lua
@@ -20,7 +20,10 @@ end
 
 local function CreateStarRatingWidget(config)
     local starGroup = AceGUI:Create("MinimalFrame")
-    starGroup:SetWidth(CalculateOffset(6, config) - (config.marginBetweenStarsX or 8))
+
+    -- Calculate width, considering leftPadding if provided
+    local leftPadding = config.leftPadding or 0  -- Default to 0 if no leftPadding is provided
+    starGroup:SetWidth(CalculateOffset(6, config) - (config.marginBetweenStarsX or 8) + leftPadding)  -- Add leftPadding to width if provided
     starGroup:SetHeight(config.panelHeight or 40)
     starGroup.rating = config.initialRating or 0
 
@@ -34,7 +37,7 @@ local function CreateStarRatingWidget(config)
     -- Create text label unless hideText is true
     if not config.hideText then
         local label = starGroup.frame:CreateFontString(nil, "OVERLAY", config.labelFont or "GameFontNormal")
-        label:SetPoint("LEFT", 0, 0)
+        label:SetPoint("LEFT", leftPadding, 0)  -- Only apply leftPadding if passed
         label:SetText(string.format("%d", starGroup.rating))
         starGroup.label = label
     end
@@ -43,7 +46,7 @@ local function CreateStarRatingWidget(config)
     for i = 1, 5 do
         local starButton = CreateFrame("Button", nil, starGroup.frame)
         starButton:SetSize(starSize + (config.hitboxPadX or 0), starSize + (config.hitboxPadY or 0))
-        starButton:SetPoint("LEFT", CalculateOffset(i, config), 0)
+        starButton:SetPoint("LEFT", leftPadding + CalculateOffset(i, config), 0)  -- Add leftPadding if provided
 
         -- Add a transparent background to increase hit area
         local background = starButton:CreateTexture(nil, "BACKGROUND")


### PR DESCRIPTION
<img src="https://github.com/user-attachments/assets/2a832d78-4c3d-40f9-b5c8-6c3afb7f3f1e" width="45%" style="display: inline-block; vertical-align: top; margin-right: 15%;" />
<img src="https://github.com/user-attachments/assets/bf0f5fa4-3a03-4344-bf01-bb46a5014793" width="45%" style="display: inline-block; vertical-align: top;" />

# Refactor & Restyle

Mainly focusing on padding adjustments.

## Todo List:
- **EditBox**: Reduce height for a more compact design.
- **Reskin button**: Update button styles for consistency.
- **Rescale entire content group**: Adjust size after all changes are completed.
- **Set a visual timer** for the next update to `playedTime`.
- **Color code `playedTime`** based on average death timers:
  - 💚 Green for fast times.
  - ❤️ Red for slow times..